### PR TITLE
[SELS-TASK] Creating Category Controller for Admin

### DIFF
--- a/app/Http/Controllers/AdminCategoryController.php
+++ b/app/Http/Controllers/AdminCategoryController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Category;
+use Illuminate\Http\Request;
+
+class AdminCategoryController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('admin');
+    }
+
+    public function index()
+    {
+        $categories = Category::all();
+
+        return view('admin.categories', compact('categories'));
+    }
+
+    public function show(Category $category)
+    {
+
+    }
+
+    public function create()
+    {
+
+    }
+
+    public function store()
+    {
+
+    }
+
+    public function edit()
+    {
+
+    }
+
+    public function update()
+    {
+
+    }
+
+    public function destroy()
+    {
+    }
+
+    protected function validateCategory(){
+        return request()->validate([
+            'title' => ['required', 'min:3'],
+            'description' => ['required', 'min:8']
+        ]);
+    }
+}

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -12,7 +12,7 @@ class AdminController extends Controller
         $this->middleware('admin');
     }
 
-    public function index(){
+    public function categories(){
         $categories = Category::all();
 
         return view('admin.categories', compact('categories'));

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -19,38 +19,6 @@ class CategoriesController extends Controller
         return view('category.show', compact('category'));
     }
 
-    public function create()
-    {
-        return view('category.create');
-    }
-
-    public function store()
-    {
-        $attributes = $this->validateCategory();
-        Category::create($attributes);
-
-        return redirect('/categories');
-    }
-
-    public function edit(Category $category)
-    {
-        return view('category.edit', compact('category'));
-    }
-
-    public function update(Category $category)
-    {
-        $category->update($this->validateCategory());
-
-        return redirect('/categories');
-    }
-
-    public function destroy(Category $category)
-    {
-        $category->delete();
-
-        return redirect('/categories');
-    }
-
     protected function validateCategory(){
         return request()->validate([
             'title' => ['required', 'min:3'],

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,6 @@ Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
 
-Route::resource('/admin/categories', 'AdminController');
+Route::resource('/admin/categories', 'AdminCategoryController');
 
 Route::resource('categories', 'CategoriesController');


### PR DESCRIPTION
Description: This PR is for the creation of the AdminCategoryController for Admin Panel. This is Back-End implementation.

[Commands]
php artisan migrate:fresh --seed  (to populate the db with 

[Pre-condition]
- Login as Non-admin (email: johndoe@gmail.com, password: securepassword)
- Go to /categories/ AND /categories/create or /categories/1/edit
- Go to /admin/categories/create or /admin/categories/1/edit
- Login as Admin (email: admin@gmail.com, password: securepassword)
- Go to /categories/ AND /categories/create or /categories/1/edit
- Go to /admin/categories/create or /admin/categories/1/edit


[Expected Output]
- As a non-admin, You should be able to see /categories/ but not /create and /$id/edit, as these functions no longer exist in the controller
- As an admin, you should be able to see /categories/, /admin/categories/create and /admin/categories/$id/edit

[Notes]
- Create and Edit should display only a blank page since I have not implemented them at this PR yet.

- This PR also includes the creation of a middleware for Admin accounts as well as moving the CRUD operators for Category from the CategoryController to AdminCategoryController.
