### PR TITLE
[SELS-TASK] Implemented Add Word Function for Admin

### DIFF
--- a/app/Choice.php
+++ b/app/Choice.php
@@ -6,5 +6,34 @@ use Illuminate\Database\Eloquent\Model;
 
 class Choice extends Model
 {
-    //
+    protected $fillable = ['word_id', 'text', 'is_correct'];
+
+    public function word()
+    {
+        return $this->belongsTo(Word::class);
+    }
+
+    public function newRecord($attributes)
+    {
+        $choices = [
+            $attributes['choice1'],
+            $attributes['choice2'],
+            $attributes['choice3'],
+            $attributes['choice4'],
+        ];
+        foreach ($choices as $key => $choice) {
+            if ($key == $attributes['answer']) {
+                $this->create([
+                    'word_id' => $attributes['word_id'],
+                    'text' => $choice,
+                    'is_correct' => 1
+                ]);
+            } else {
+                $this->create([
+                    'word_id' => $attributes['word_id'],
+                    'text' => $choice,
+                ]);
+            }
+        }
+    }
 }

--- a/app/Http/Controllers/AdminWordsController.php
+++ b/app/Http/Controllers/AdminWordsController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Word;
+use App\Category;
+use Illuminate\Http\Request;
+use App\Http\Requests\CreateWord;
+
+class AdminWordsController extends Controller
+{
+    public function create(Category $category)
+    {
+        return view('admin.word.create', compact('category'));
+    }
+
+    public function store(Category $category, CreateWord $request)
+    {
+        $attributes = $request->validated();
+        $attributes['category_id'] = $category->id;
+        (new Word)->newRecord($attributes);
+        session()->flash('message', $attributes['text'].' has been added to ' . $category->title);
+
+        return redirect('/admin/categories');
+    }
+}

--- a/app/Http/Requests/CreateWord.php
+++ b/app/Http/Requests/CreateWord.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateWord extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'text' => ['required', 'min:1'],
+            'choice1' => ['required', 'min:3'],
+            'choice2' => ['required', 'min:3'],
+            'choice3' => ['required', 'min:3'],
+            'choice4' => ['required', 'min:3'],
+            'answer' => ['required'],
+        ];
+    }
+}

--- a/app/Word.php
+++ b/app/Word.php
@@ -2,10 +2,12 @@
 
 namespace App;
 
+use App\Choice;
 use Illuminate\Database\Eloquent\Model;
 
 class Word extends Model
 {
+    protected $fillable = ['text', 'category_id'];
 
     public function category()
     {
@@ -15,5 +17,15 @@ class Word extends Model
     public function choices()
     {
         return $this->hasMany(Choice::class);
+    }
+
+    public function newRecord($attributes){
+        $record = $this->create([
+            'category_id' => $attributes['category_id'],
+            'text' => $attributes['text'],
+        ]);
+        $attributes['word_id'] = $record->id;
+        $attributes = collect($attributes)->forget('category_id')->forget('text');
+        (new Choice)->newRecord($attributes);
     }
 }

--- a/resources/views/admin/category/categories.blade.php
+++ b/resources/views/admin/category/categories.blade.php
@@ -15,6 +15,13 @@
 </div>
 <div class="row">
     <div class="col-lg-12">
+        @if (session('message'))
+            <div class="alert alert-success" role="alert">
+                {{ session('message') }}
+            </div>
+        @endif
+    </div>
+    <div class="col-lg-12">
         <table class="table table-striped">
             <thead class="thead-dark">
             <tr>

--- a/resources/views/admin/word/create.blade.php
+++ b/resources/views/admin/word/create.blade.php
@@ -1,0 +1,73 @@
+@extends('layout')
+
+@section('content')
+<div class="row justify-content-center">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <b>Add Word</b>
+                </div>
+                <div class="card-body">
+                    <form action="/admin/categories/{{ $category->id }}/words" method="POST">
+                        @csrf
+                        <div class="row">
+                            <div class="col-md-4">
+                                <div class="form-group">
+                                    <label for="text">Word</label>
+                                    <input type="text" name="text" id="text" class="form-control" placeholder="E.g 人" required>
+                                </div>
+                            </div>
+                            <div class="col-md-8">
+                                <div class="form-group">
+                                    <label for="title">Choices</label>
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">
+                                            <input type="radio" name="answer" value="0" required>
+                                            </div>
+                                        </div>
+                                        <input type="text" name="choice1" id="choice1" class="form-control" required>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">
+                                            <input type="radio" name="answer" value="1">
+                                            </div>
+                                        </div>
+                                        <input type="text" name="choice2" id="choice2" class="form-control" required>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">
+                                            <input type="radio" name="answer" value="2">
+                                            </div>
+                                        </div>
+                                        <input type="text" name="choice3" id="choice3" class="form-control" required>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <div class="input-group-text">
+                                            <input type="radio" name="answer" value="3">
+                                            </div>
+                                        </div>
+                                        <input type="text" name="choice4" id="choice4" class="form-control" required>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <button type="submit" class="btn btn-success float-right">Add Word</button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            @include('errors')
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,11 @@ Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
 
-Route::resource('/admin/categories', 'AdminCategoryController');
+Route::prefix('admin')->group(function (){
+    Route::resource('/categories', 'AdminCategoryController');
+    Route::post('/categories/{category}/words', 'AdminWordsController@store');
+    Route::get('/categories/{category}/words/create', 'AdminWordsController@create');
+
+});
 
 Route::resource('categories', 'CategoriesController');


### PR DESCRIPTION
Description: This PR is a Back-End implementation for Add Word Function for the Admin Panel.

[Commands]
- php artisan migrate:fresh --seed

[Pre-condition]
- Login as Admin (Username: admin@gmail.com, Password: securepassword)
- Proceed to /admin/categories/
- Add a Word by clicking on 'Add Word'
- Input word text
- Input the four choices
- Click the radiobutton for the Correct answer
- Click Save
- Click the category that you added a word to

[Expected Output]
- The page should redirect to /admin/categories
- After going to the Category Page, the new word should be in the list

[Notes]
- The redirect is fixed in a different PR where the page would redirect to the category that was added a word to.