### PR TITLE
[SELS-TASK] Implemented Category Delete Cascading Function

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -21,4 +21,13 @@ class Category extends Model
     {
         return $this->hasMany(Lesson::class);
     }
+
+    public function deleteRecord()
+    {
+        $words = $this->words;
+        foreach($words as $word) {
+            $word->deleteRecord();
+            $word->delete();
+        }
+    }
 }

--- a/app/Http/Controllers/AdminCategoryController.php
+++ b/app/Http/Controllers/AdminCategoryController.php
@@ -53,6 +53,7 @@ class AdminCategoryController extends Controller
 
     public function destroy(Category $category)
     {
+        $category->deleteRecord();
         $category->delete();
 
         return redirect('/admin/categories');

--- a/app/Word.php
+++ b/app/Word.php
@@ -39,15 +39,15 @@ class Word extends Model
         $choices->updateRecord($attributes);
     }
 
-    public function deleteRecord(Word $word)
+    public function deleteRecord()
     {
-        $choices = $word->choices;
+        $choices = $this->choices;
 
         foreach ($choices as $choice)
         {
             $choice->delete();
         }
 
-        return redirect('/admin/categories/' . $word->category->id);
+        return redirect('/admin/categories/' . $this->category->id);
     }
 }

--- a/database/migrations/2019_06_24_021225_create_lessons_table.php
+++ b/database/migrations/2019_06_24_021225_create_lessons_table.php
@@ -18,8 +18,8 @@ class CreateLessonsTable extends Migration
             $table->unsignedBigInteger('category_id');
             $table->unsignedBigInteger('user_id');
             $table->timestamps();
-            $table->foreign('category_id')->references('id')->on('categories');
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -42,17 +42,7 @@ class DatabaseSeeder extends Seeder
                 'title' => 'Seeded Project 1',
                 'description' => 'Project Description',
                 'created_at' => Carbon::now()
-            ],
-            [
-                'title' => 'Seeded Project 2',
-                'description' => 'Project Description',
-                'created_at' => Carbon::now()
-            ],
-            [
-                'title' => 'Seeded Project 3',
-                'description' => 'Project Description',
-                'created_at' => Carbon::now()
-            ],
+            ]
         ]);
 
         DB::table('words')->insert([


### PR DESCRIPTION
Description: This PR is for the implementation of Delete Category Function that cascades. This means that once a category is deleted by an admin, all of it's corresponding Words and Choices would also be deleted.

[Commands]
- php artisan migrate:fresh --seed

[Pre-condition]
- Login as Admin (email: admin@gmail.com, password: securepassword)
- Go to /admin/categories
- Delete the seeded category

[Expected Output]
- The page should refresh
- The list should then be empty
- Go to localhost/phpmyadmin
- Choices, Words, and Categories table should be empty.

[Notes]
- No notes as of now