### PR TITLE
[SELS-TASK] Empty Categories Should not Display in Category List

### DIFF
--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -9,7 +9,9 @@ class CategoriesController extends Controller
 {
     public function index()
     {
-        $categories = Category::all();
+        $categories = Category::all()->map(function ($category){
+            return $category->words->count() > 0 ? $category : null;
+        })->filter();
 
         return view('category.categories', compact('categories'));
     }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -42,6 +42,11 @@ class DatabaseSeeder extends Seeder
                 'title' => 'Seeded Project 1',
                 'description' => 'Project Description',
                 'created_at' => Carbon::now()
+            ],
+            [
+                'title' => 'Seeded Project 2',
+                'description' => 'Project Description',
+                'created_at' => Carbon::now()
             ]
         ]);
 
@@ -76,19 +81,6 @@ class DatabaseSeeder extends Seeder
                 'text' => 'Choice 4',
                 'created_at' => Carbon::now()
             ],
-        ]);
-
-        DB::table('lessons')->insert([
-            [
-                'category_id' => 1,
-                'user_id' => 2,
-                'created_at' => Carbon::now()
-            ],
-            [
-                'category_id' => 1,
-                'user_id' => 3,
-                'created_at' => Carbon::now()
-            ]
         ]);
     }
 }


### PR DESCRIPTION
Description: This PR is a Front-End implementation of Category Listing Filters. The Users should only be able to take lessons for categories that are not empty.

[Commands]
- php artisan migrate:fresh --seed

[Pre-condition]
- Login as Non-Admin
- Go to /categories

[Expected Output]
- Despite having multiple categories in the DB, Only One should display.

[Notes]
- No notes at this time.