### PR TITLE
[SELS-TASK] Implemented Single-Take Category Function

### DIFF
--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -2,15 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Lesson;
 use App\Category;
+use Illuminate\Http\Request;
 
 class CategoriesController extends Controller
 {
     public function index()
     {
         $categories = Category::all()->map(function ($category){
-            return $category->words->count() > 0 ? $category : null;
+            $lesson = $category->lessons->whereIn('user_id', auth()->id());
+            if($category->words->count() && !$lesson->count()) {
+                return $category;
+            }
         })->filter();
 
         return view('category.categories', compact('categories'));

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -82,5 +82,13 @@ class DatabaseSeeder extends Seeder
                 'created_at' => Carbon::now()
             ],
         ]);
+
+        DB::table('lessons')->insert([
+            [
+                'category_id' => 1,
+                'user_id' => 2,
+                'created_at' => Carbon::now()
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
Descriptions: This is for the Front-End Implementation. Once a user decides to take a Lesson for a Certain Category, they should not be able to re-take it again. I've added this filter to the Category List so that the users can only choose from the categories they have not taken yet.

[Commands]
- php artisan migrate::fresh --seed (The DB will now have only 2 Categories, One the user has already taken, and the other is empty)

[Pre-Condition]
- Login as Non-Admin (Email: johndoe@gmail.com, Password: securepassword)
- Go to /categories
- Go to /lessons

- Now, Login as Admin (Email: admin@gmail.com, Password: securepassword)
- Go to /admin/categories/
- Add a word to **Seeded Project 2**

- Login again as Non-Admin
- Go to /categories
- Click **Start Lesson*
- Go back to /categories

[Expected Output]
- Initially, the Categories Page should be empty
- The Lessons page should have 1 entry

**After Adding Word to Seeded Project 2**
- The categories page should have Seeded Project 2
- The category should be added to the /lessons list after clicking **Start Lesson**
- The category page should be empty again

[Note]
- There should be a quiz right after clicking 'Start Lesson' but I still have not implemented that yet, so right now it's just going with the assumption that the user has 'finished' taking the quiz.